### PR TITLE
Update gas_cost_estimator.py

### DIFF
--- a/gas_cost_estimator.py
+++ b/gas_cost_estimator.py
@@ -58,6 +58,7 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
     w3 = connect(args.rpc)
+    print(f"🔗 Connected to RPC endpoint: {args.rpc}")
     chain_id = int(w3.eth.chain_id)
     network = network_name(chain_id)
 


### PR DESCRIPTION
61 - Shows which RPC endpoint the script is connected to. Helpful if you’re switching between providers (Infura, Ankr, Alchemy, etc.).