### PR TITLE
Update proof_cost_auditor.py

### DIFF
--- a/proof_cost_auditor.py
+++ b/proof_cost_auditor.py
@@ -76,6 +76,8 @@ def audit_tx(w3: Web3, tx_hash: str, tip_threshold: float, gas_used_threshold: i
 def main():
     args = parse_args()
     w3 = connect(args.rpc)
+  print(f"🌐 Auditing on network: {network_name(int(w3.eth.chain_id))} (chainId {w3.eth.chain_id})")  
+print("—" * 60)
     hashes = read_tx_hashes(args.file)
     results = [audit_tx(w3, h, args.tip_threshold, args.gas_used_threshold) for h in hashes]
 


### PR DESCRIPTION
79-80 Immediately shows which network the script is operating on — reducing confusion if you switch RPC endpoints.