### PR TITLE
Update eip4844_blob_cost.py

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -83,6 +83,9 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
     w3 = connect(args.rpc)
+    print(f"🔍 RPC connected: {args.rpc}")  
+print(f"🧮 Blob size assumption: {BLOB_SIZE_BYTES} bytes per blob")  
+
     chain_id = int(w3.eth.chain_id)
     latest = w3.eth.get_block("latest")
     base_fee_gwei = float(Web3.from_wei(int(latest.get("baseFeePerGas", 0)), "gwei"))


### PR DESCRIPTION
86-87 - сonfirms exactly which RPC endpoint is being used, helping track which provider or environment the estimate is based on.