### PR TITLE
Update eip4844_blob_cost.py

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -147,6 +147,8 @@ def main():
     print(f"⛽ Base fee: {out['baseFeeGwei']} Gwei   🎁 Tip: {out['tipGwei']} Gwei   ⚙️ Eff: {out['effectivePriceGwei']} Gwei")
     if out["blobBaseFeeGwei"] is not None:
         print(f"🫧 Blob base fee: {out['blobBaseFeeGwei']} Gwei")
+        print(f"📏 Blobs size per unit: {BLOB_SIZE_BYTES} bytes/blob")
+print(f"🔍 Call data cost equivalent shown when `--calldata-bytes` used")
     print(f"📥 Inputs → gasUsed={args.gas_used}  blobs={args.blobs}  calldataBytes={args.calldata_bytes}")
     print("— Estimated Costs (ETH) —")
     print(f"   • Execution       : {out['costsETH']['execution']}")


### PR DESCRIPTION
149 - line clarifies how many bytes a blob contains, which helps users understand the scaling difference between blob vs calldata