### PR TITLE
No validation for negative inputs (gas, blobs, calldata bytes) eip484…

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -82,6 +82,9 @@ def parse_args() -> argparse.Namespace:
 
 def main():
     args = parse_args()
+    args.gas_used = max(0, args.gas_used)
+args.calldata_bytes = max(0, args.calldata_bytes)
+
     w3 = connect(args.rpc)
     chain_id = int(w3.eth.chain_id)
     latest = w3.eth.get_block("latest")


### PR DESCRIPTION
…4_blob_cost.py

Issue: Negative CLI values can slip through and create nonsense costs.