### PR TITLE
Division by zero / None confusion in any future ratio math eip4844_bl…

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -154,6 +154,9 @@ def main():
         print(f"   • Blobs (data)    : {out['costsETH']['blobs']}")
     if out["costsETH"]["calldata"] is not None:
         print(f"   • Calldata (data) : {out['costsETH']['calldata']}")
+        # only show ratio when both are present and calldata cost > 0
+if calld_cost_eth and blob_cost_eth: print(f"📊 Ratio blob-to-calldata: {round(blob_cost_eth / calld_cost_eth, 2)}×")
+
     if out["notes"]:
         print("ℹ️  Notes:")
         for n in out["notes"]:


### PR DESCRIPTION
…ob_cost.py

If either cost is None or 0, a ratio would crash or be meaningless.