### PR TITLE
Update eip4844_blob_cost.py

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -94,6 +94,9 @@ def main():
     # Execution gas cost (EIP-1559): (base + tip) * gas_used
     eff_gwei = base_fee_gwei + args.tip_gwei
     exec_cost_eth = float(Web3.from_wei(Web3.to_wei(eff_gwei, "gwei") * max(args.gas_used, 0), "ether"))
+    if args.eth_price is not None:
+    print(f"💱 Estimated cost in USD: ~${round(exec_cost_eth * args.eth_price,2)} (excluding data fees)")
+
 
     # Blob data cost: blob_base_fee * blobs * (data gas per blob == 1 unit)
     # In EIP-4844, blob gas is separate; we treat 1 blob gas unit per blob at blobBaseFee.


### PR DESCRIPTION
97-98 - Translates technical gas cost into USD equivalent, making the output more immediately relevant for budgeting or management.