### PR TITLE
Oversized payload can overflow a blob

### DIFF
--- a/blob_packing_planner.py
+++ b/blob_packing_planner.py
@@ -131,6 +131,9 @@ def main():
     else:
         sizes = read_sizes_file(args.file)
     sizes = [max(0, s) for s in sizes]
+    if any(s > BLOB_SIZE_BYTES for s in sizes):
+    raise ValueError(f"Payload exceeds blob capacity ({BLOB_SIZE_BYTES} bytes); split payloads before packing.")
+
     total_bytes = sum(sizes)
 
     w3 = connect(args.rpc)


### PR DESCRIPTION
If any payload size > BLOB_SIZE_BYTES (128 KiB), the “new bin” branch doesn’t validate capacity. You’ll end up with a blob whose remaining becomes negative and wrong costs.