### PR TITLE
Possible negative/garbage --gas-used value slips through

### DIFF
--- a/blob_packing_planner.py
+++ b/blob_packing_planner.py
@@ -124,6 +124,8 @@ def parse_args() -> argparse.Namespace:
 
 def main():
     args = parse_args()
+    args.gas_used = max(0, int(args.gas_used))
+
 
     # Read and validate sizes
     if args.sizes:


### PR DESCRIPTION
`Clamp` in the cost formula (max(0, args.gas_used)), but it’s better to normalize once and print the normalized value