### PR TITLE
Lots of receipts ⇒ throttling/errors (429/timeout) with no retry

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -87,7 +87,14 @@ def scan(w3: Web3, blocks: int, step: int,
         # Iterate transactions in block
         for tx in blk.transactions:
             try:
-                rcpt = w3.eth.get_transaction_receipt(tx["hash"])
+               for _ in range(2):
+    try:
+        rcpt = w3.eth.get_transaction_receipt(tx["hash"])
+        break
+    except Exception:
+        rcpt = None
+if rcpt is None:
+    continue
             except Exception:
                 continue
             if rcpt is None or rcpt.blockNumber is None:


### PR DESCRIPTION
Script exits mid-scan due to transient RPC errors