### PR TITLE
Zero-basefee chains (or pre-1559) mislead output

### DIFF
--- a/scanner.py
+++ b/scanner.py
@@ -82,6 +82,10 @@ def scan(w3: Web3, blocks: int, step: int,
     for n in range(head, start - 1, -step):
         blk = w3.eth.get_block(n, full_transactions=True)
         base_fee_wei = int(blk.get("baseFeePerGas", 0))
+if int(base_fee_wei or 0) == 0:
+    # Optional: mark no-1559 path, or skip tip-based flags
+    tip_gwei = 0.0
+
         ts_utc = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(blk.timestamp))
 
         # Iterate transactions in block


### PR DESCRIPTION
Base fee shows 0; your tip/eff calcs still run, producing confusing numbers.