### PR TITLE
Update proof_cost_auditor.py

### DIFF
--- a/proof_cost_auditor.py
+++ b/proof_cost_auditor.py
@@ -76,6 +76,9 @@ def audit_tx(w3: Web3, tx_hash: str, tip_threshold: float, gas_used_threshold: i
 def main():
     args = parse_args()
     w3 = connect(args.rpc)
+  if w3.eth.chain_id != 1:
+    print(f"⚠️  Warning: You are connected to a test network (chainId {w3.eth.chain_id}). Results may differ from mainnet.")
+
   print(f"🕒 Audit initiated at {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())} UTC")
     hashes = read_tx_hashes(args.file)
     results = [audit_tx(w3, h, args.tip_threshold, args.gas_used_threshold) for h in hashes]


### PR DESCRIPTION
80 - it warns the user if the RPC endpoint is running on a testnet instead of mainnet.