### PR TITLE
Update eip4844_blob_cost.py

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -83,6 +83,8 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
     w3 = connect(args.rpc)
+    print(f"🌐 Connected to network ID: {w3.eth.chain_id}")
+print(f"📡 RPC Endpoint: {args.rpc}")
     chain_id = int(w3.eth.chain_id)
     latest = w3.eth.get_block("latest")
     base_fee_gwei = float(Web3.from_wei(int(latest.get("baseFeePerGas", 0)), "gwei"))


### PR DESCRIPTION
84-85 -  shows the chain ID and RPC endpoint, making it easier to confirm the correct network (e.g., Mainnet vs. Sepolia).