### PR TITLE
Update eip4844_blob_cost.py

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -83,6 +83,8 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
     w3 = connect(args.rpc)
+    print(f"📥 Inputs → gasUsed={args.gas_used}, blobs={args.blobs}, calldataBytes={args.calldata_bytes}")
+    print(f"🔧 Blobs mode: using blob-base-fee override={args.blob_base_fee_gwei}")
     chain_id = int(w3.eth.chain_id)
     latest = w3.eth.get_block("latest")
     base_fee_gwei = float(Web3.from_wei(int(latest.get("baseFeePerGas", 0)), "gwei"))


### PR DESCRIPTION
86-87 - clearly shows what parameters the user provided (gas usage, blob count, calldata bytes) , helpful for logging or debugging runs.