### PR TITLE
Optional PoA middleware for L2s / testnets

### DIFF
--- a/proof_cost_auditor.py
+++ b/proof_cost_auditor.py
@@ -34,9 +34,16 @@ def network_name(cid: int) -> str:
 def connect(rpc: str) -> Web3:
     w3 = Web3(Web3.HTTPProvider(rpc, request_kwargs={"timeout": 20}))
     if not w3.is_connected():
-        print("❌ Failed to connect to RPC.", file=sys.stderr)
+        print(f"❌ Failed to connect to RPC: {rpc}", file=sys.stderr)
         sys.exit(1)
+    # Improve compatibility for PoA / some L2 chains
+    try:
+        from web3.middleware import geth_poa_middleware
+        w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    except Exception:
+        pass
     return w3
+
 
 def read_tx_hashes(file: str) -> List[str]:
     with open(file, "r", encoding="utf-8") as f:


### PR DESCRIPTION
Some L2 / sidechain / PoA networks require geth_poa_middleware. This is a no-op if not needed