### PR TITLE
Graceful file read error handling

### DIFF
--- a/proof_cost_auditor.py
+++ b/proof_cost_auditor.py
@@ -39,8 +39,16 @@ def connect(rpc: str) -> Web3:
     return w3
 
 def read_tx_hashes(file: str) -> List[str]:
-    with open(file, "r", encoding="utf-8") as f:
-        return [line.strip() for line in f if line.strip()]
+    try:
+        with open(file, "r", encoding="utf-8") as f:
+            return [line.strip() for line in f if line.strip()]
+    except FileNotFoundError:
+        print(f"❌ File not found: {file}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f"❌ Failed to read file {file}: {e}", file=sys.stderr)
+        sys.exit(1)
+
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Audit zk-proof or rollup transaction costs for soundness.")


### PR DESCRIPTION
If the file doesn’t exist or is unreadable, you currently get a traceback. Better to exit with a clear error