### PR TITLE
Show thresholds in the text header

### DIFF
--- a/proof_cost_auditor.py
+++ b/proof_cost_auditor.py
@@ -84,7 +84,12 @@ def main():
         print(json.dumps(results, indent=2, sort_keys=True))
     else:
         print(f"🌐 {network_name(int(w3.eth.chain_id))} (chainId {w3.eth.chain_id})")
-        print("🔍 Proof cost audit results:")
+        print(
+            "🔍 Proof cost audit results "
+            f"(tip threshold {args.tip_threshold} Gwei, "
+            f"gasUsed threshold {args.gas_used_threshold})"
+        )
+
         for r in results:
             flagstr = f"  🏷️ Flags: {','.join(r['flags'])}" if r.get("flags") else ""
             print(f"- {r['txHash']} | block {r['blockNumber']} | gasUsed {r['gasUsed']} | tip {r['tipGwei']:.2f} Gwei{flagstr}")


### PR DESCRIPTION
When running audits, it’s nice to see what thresholds you used at a glance