### PR TITLE
Handle KeyboardInterrupt cleanly

### DIFF
--- a/proof_cost_auditor.py
+++ b/proof_cost_auditor.py
@@ -90,4 +90,9 @@ def main():
             print(f"- {r['txHash']} | block {r['blockNumber']} | gasUsed {r['gasUsed']} | tip {r['tipGwei']:.2f} Gwei{flagstr}")
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\n🛑 Audit aborted by user.", file=sys.stderr)
+        sys.exit(1)
+


### PR DESCRIPTION
Ctrl+C currently produces a traceback. This turns it into a clean “aborted” message.