### PR TITLE
Warn on placeholder Infura URL (your_api_key)

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -82,6 +82,14 @@ def parse_args() -> argparse.Namespace:
 
 def main():
     args = parse_args()
+
+    if "your_api_key" in args.rpc:
+        print(
+            "❌ RPC URL appears to still contain the placeholder 'your_api_key'. "
+            "Set RPC_URL or pass --rpc with a real endpoint.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     w3 = connect(args.rpc)
     chain_id = int(w3.eth.chain_id)
     latest = w3.eth.get_block("latest")


### PR DESCRIPTION
Catch the classic “forgot to set key” error early