### PR TITLE
Validate inputs are non-negative and not all zero

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -82,6 +82,28 @@ def parse_args() -> argparse.Namespace:
 
 def main():
     args = parse_args()
+
+    if "your_api_key" in args.rpc:
+        print(
+            "❌ RPC URL appears to still contain the placeholder 'your_api_key'. "
+            "Set RPC_URL or pass --rpc with a real endpoint.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if args.gas_used < 0:
+        print(f"❌ --gas-used must be ≥ 0 (got {args.gas_used})", file=sys.stderr)
+        sys.exit(1)
+    if args.blobs < 0:
+        print(f"❌ --blobs must be ≥ 0 (got {args.blobs})", file=sys.stderr)
+        sys.exit(1)
+    if args.calldata_bytes < 0:
+        print(f"❌ --calldata-bytes must be ≥ 0 (got {args.calldata_bytes})", file=sys.stderr)
+        sys.exit(1)
+
+    if args.gas_used == 0 and args.blobs == 0 and args.calldata_bytes == 0:
+        print("⚠️  All inputs are zero (no execution gas, blobs, or calldata). Nothing to estimate.")
+        sys.exit(0)
+
     w3 = connect(args.rpc)
     chain_id = int(w3.eth.chain_id)
     latest = w3.eth.get_block("latest")


### PR DESCRIPTION
Negative gas / bytes / blob counts don’t make sense; and if everything is 0, there’s nothing to estimate.