### PR TITLE
Error handling for get_block("latest")

### DIFF
--- a/eip4844_blob_cost.py
+++ b/eip4844_blob_cost.py
@@ -54,7 +54,11 @@ def try_get_blob_base_fee_gwei(w3: Web3) -> Optional[float]:
       - eth_blobBaseFee (non-standard RPC on some providers)
     """
     try:
+            try:
         latest = w3.eth.get_block("latest")
+    except Exception as e:
+        print(f"❌ Failed to fetch latest block: {e}", file=sys.stderr)
+        sys.exit(1)
         v = latest.get("blobBaseFeePerGas", None)
         if v is not None:
             return float(Web3.from_wei(int(v), "gwei"))


### PR DESCRIPTION
If get_block fails (temporary RPC issue), you get a traceback. Handle it and exit nicely