### PR TITLE
Warn on placeholder Infura URL (your_api_key)

### DIFF
--- a/blob_packing_planner.py
+++ b/blob_packing_planner.py
@@ -125,6 +125,15 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
 
+    if "your_api_key" in args.rpc:
+        print(
+            "❌ RPC URL appears to still contain the placeholder 'your_api_key'. "
+            "Set RPC_URL or pass --rpc with a real endpoint.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
     # Read and validate sizes
     if args.sizes:
         sizes = parse_sizes_arg(args.sizes)


### PR DESCRIPTION
Catch the common “left the placeholder in the RPC URL” mistake