### PR TITLE
Avoid recomputing payload sums in bins loop

### DIFF
--- a/blob_packing_planner.py
+++ b/blob_packing_planner.py
@@ -176,15 +176,16 @@ def main():
             "blobs": round(blob_cost_eth, 8) if blob_cost_eth is not None else None,
             "calldata": round(calldata_cost_eth, 8),
         },
-        "bins": [
+            "bins": [
             {
                 "blobIndex": i,
                 "payloadIndices": bin_,
-                "payloadBytes": sum(sizes[j] for j in bin_),
-                "freeBytes": BLOB_SIZE_BYTES - sum(sizes[j] for j in bin_),
+                "payloadBytes": sum_bytes := sum(sizes[j] for j in bin_),
+                "freeBytes": BLOB_SIZE_BYTES - sum_bytes,
             }
             for i, bin_ in enumerate(bins)
         ],
+
         "notes": [],
     }
 


### PR DESCRIPTION
ompute sum(sizes[j] for j in bin_) twice per bin; tiny efficiency & clarity improvement