### PR TITLE
Sort table rows by name for a stable, readable output

### DIFF
--- a/multi_chain_monitor.py
+++ b/multi_chain_monitor.py
@@ -275,9 +275,20 @@ def main() -> None:
     args = parse_args()
     rpcs, names = resolve_rpcs_and_names(args)
 
-    results: List[Dict[str, Any]] = [
-        probe_rpc(rpc, args.warn_ratio_high, args.warn_ratio_low) for rpc in rpcs
-    ]
+      results: List[Dict[str, Any]] = []
+    for rpc, name in zip(rpcs, names):
+        probe_result = probe_rpc(
+            rpc,
+            args.warn_ratio_high,
+            args.warn_ratio_low,
+            args.timeout,
+        )
+        probe_result["name"] = name
+        results.append(probe_result)
+
+    # Sort by name for stable, readable output
+    combined = sorted(zip(names, results), key=lambda pair: pair[0])
+    names, results = [c[0] for c in combined], [c[1] for c in combined]
 
     timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
 


### PR DESCRIPTION
If you pass many --rpc flags, it’s nice when the output is sorted alphabetically by name. That’s a tiny UX improvement and easy PR.