### PR TITLE
Add totalTxs and avgTxPerBlock to result

### DIFF
--- a/gas_fee_profile.py
+++ b/gas_fee_profile.py
@@ -176,10 +176,12 @@ def analyze(
     except Exception:
         cid = None
 
-    return {
+         return {
         "chainId": cid,
         "network": network_name(cid),
         "avgBlockTimeSec": round(block_time_avg, 2),
+        "totalTxs": total_txs,
+        "avgTxsPerBlock": round(avg_txs_per_block, 2),
         "head": head,
         "sampledBlocks": len(range(head, start - 1, -step)),
         "blockSpan": blocks,


### PR DESCRIPTION
already gather all txs via eff_prices / tips, but don’t expose a total count or tx density. These metrics are useful for understanding block load.